### PR TITLE
Update estate bill management controller

### DIFF
--- a/app/EstateBills.php
+++ b/app/EstateBills.php
@@ -15,5 +15,6 @@ class EstateBills extends Model
         'item',
         'icon_link',
         'base_amount',
+        'estates_id'
     ];
 }

--- a/app/Http/Controllers/EstateBills/Admin/AddBills.php
+++ b/app/Http/Controllers/EstateBills/Admin/AddBills.php
@@ -2,13 +2,77 @@
 
 namespace App\Http\Controllers\EstateBills\Admin;
 
+use Illuminate\Database\QueryException;
 use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\Request;
+use App\EstateBills;
+use App\Estate;
+use App\User;
 
 class AddBills extends Controller
 {
-	public function __invoke()
+    /**
+     * Gets authenticated user's data
+     *
+     * @return App\User
+     */
+    public function __construct()
+    {
+        $this->user = auth()->user();
+    }
+
+	/**
+	 * Add a new billable item
+	 * 
+     * @return \Illuminate\Http\Response
+	 */
+	public function __invoke($estate_id, Request $request, EstateBills $bills)
 	{
-		
+		// Verify the admin user's association with the estate
+        $estates_administered = $this->user->home()->pluck('estate_id')->toArray();
+
+		if (!in_array($estate_id, $estates_administered)) {
+            return response()->json([
+                'status'  => false,
+                'message' => 'You are not authorised to administrate this estate'
+            ], 403);
+		}
+
+        $estate_name = Estate::whereId($estate_id)->first('estate_name');
+
+		// Validate posted data
+        $this->validate($request, [
+            'item'        => ['required', 'string'],
+            'icon_link'   => ['required', 'string'],
+            'base_amount' => ['required', 'between:0,99.99'],
+        ]);
+
+        // Pass in required validated data for record entry
+        $validated = $request->only('item', 'icon_link', 'base_amount');
+
+        // Reference and fill the estate id
+        $validated['estates_id'] = (int) $estate_id;
+
+        // Save new entry to record
+        try 
+        {
+	        $saved = $bills->create($validated);
+
+            return response()->json([
+                'status'  => true,
+                'data'	  => $saved,
+                'message' => "Item: {$bills->name} has been added as a billable item for {$estate_name['estate_name']}"
+            ], 200);
+        }
+        catch(QueryException $e)
+        {
+            return response()->json([
+                'status'  => false,
+                'message' => "Item: {$request->name} could not be added as a billable item for {$estate_name['estate_name']}. Try again!",
+                'hint'	  => $e->getMessage()
+            ], 501);
+        }
 	}
 }
+

--- a/app/Http/Controllers/EstateBills/Admin/AddBills.php
+++ b/app/Http/Controllers/EstateBills/Admin/AddBills.php
@@ -62,7 +62,7 @@ class AddBills extends Controller
             return response()->json([
                 'status'  => true,
                 'data'	  => $saved,
-                'message' => "Item: {$bills->name} has been added as a billable item for {$estate_name['estate_name']}"
+                'message' => "Item: {$saved->item} has been added as a billable item for {$estate_name['estate_name']}"
             ], 200);
         }
         catch(QueryException $e)

--- a/routes/v1.php
+++ b/routes/v1.php
@@ -214,7 +214,7 @@ Route::group(['middleware' => ['jwt.verify']], function () {
         // for estate admin satisfied privileges
         Route::namespace('EstateBills\Admin')->group(function () {
             Route::middleware(['estateAdmin'])->group(function(){
-                Route::post('estate', AddBills::class);
+                Route::post('estate/{estate_id}', AddBills::class);
             });
         });
 


### PR DESCRIPTION
## Summary 
- **Set estates_id as mass fillable:** Formerly, the estates db resource identifier was not mass fillable making it impossible for any new record to be saved. Since, the estate id had to be passed to the estate bill model, there is need for it to be mass fillable.
- **Add method for adding new billable item:** The controller for adding new billable item is created. This can only be accessed by an admin user.
- **Update estate bill console route:** Actually, the route for adding billable items to an estate was `api/v1/bills/estate`. The old route will cause some issues in future if an estate admin happens to administer more than one estates. Yea, it sounds impossible, but has a possibility of an occurrence. To prevent such, the estate id should be passed in, in the request parameter to avoid such an occurrence. This PR with the [commit](https://github.com/hngi/Gateapp-api/commit/5e5d46bb166ce751029f2c69f9b6de62af92db0d) solves that issue, thereby changing the route to `api/v1/bills/estate/{estate_id}`

## Test
This pull request has been tested using Postman. A JSON body-data is sent to the endpoint `api/v1/bills/estate/3` where **3** is the estate_id
```json
{
	"item": "Electricity",
	"icon_link": "no-image.jpg",
	"base_amount": 1200.00
}
```
- **item:** This is the naming of the billable item. It could be electricity or water or internet. It is required.
- **icon_link:** This is the link to the icon of the item. It is required.
- **base_amount:** This is the floor amount of the billable item. Let's say, the estate admin sets the electricity bill at ₦1,200.00 for an hourly consumption. The amount will be used in conjunction with the resident's usage rate to calculate the total amount billable. **Float must be pass.**

Here is the success result in JSON
```json
{
    "status": true,
    "data": {
        "item": "Electricity",
        "icon_link": "no-image.jpg",
        "base_amount": 1200,
        "estates_id": 3,
        "updated_at": "2019-11-21 22:29:39",
        "created_at": "2019-11-21 22:29:39",
        "id": 6
    },
    "message": "Item: Electricity has been added as a billable item for Peace Estate"
}
```
And a screenshot of the success screen:

![image](https://user-images.githubusercontent.com/54823365/69382252-f27bc400-0cb6-11ea-8b5d-72a45fbf7597.png)


