### PR TITLE
Add method to get billable items

### DIFF
--- a/app/Estate.php
+++ b/app/Estate.php
@@ -21,6 +21,8 @@ class Estate extends Model
      */
     public function billableItems()
     {
-        return $this->hasMany(EstateBills::class);
+        return $this->hasMany(EstateBills::class)->select([
+            'id as estate_bills_id', 'item', 'icon_link', 'base_amount'
+        ]);
     }
 }

--- a/app/Estate.php
+++ b/app/Estate.php
@@ -12,4 +12,15 @@ class Estate extends Model
     {
         return $this->hasMany(Service_Provider::class);
     }
+
+    /**
+     * Joins Estate model with EstateBills model
+     *
+     * @see Laravel Eloquent Relationship (https://laravel.com/docs/6.x/eloquent-relationships)
+     * @return App\EstateBills
+     */
+    public function billableItems()
+    {
+        return $this->hasMany(EstateBills::class);
+    }
 }

--- a/app/EstateBills.php
+++ b/app/EstateBills.php
@@ -17,4 +17,15 @@ class EstateBills extends Model
         'base_amount',
         'estates_id'
     ];
+
+    /**
+     * Joins Estate model with EstateBills model
+     *
+     * @see Laravel Eloquent Relationship (https://laravel.com/docs/6.x/eloquent-relationships)
+     * @return App\EstateBills
+     */
+    public function estates()
+    {
+        return $this->belongsTo(Estate::class);
+    }
 }

--- a/app/Http/Controllers/EstateBills/Residents/GetAllBills.php
+++ b/app/Http/Controllers/EstateBills/Residents/GetAllBills.php
@@ -47,7 +47,7 @@ class GetAllBills extends Controller
         return response()->json([
         	'count'   => $estate_bills->count(),
             'status'  => true,
-            'data'	  => $estate_bills
+            'data'	  => $estate
         ], 200);
 	}
 }

--- a/app/Http/Controllers/EstateBills/Residents/GetAllBills.php
+++ b/app/Http/Controllers/EstateBills/Residents/GetAllBills.php
@@ -3,12 +3,51 @@
 namespace App\Http\Controllers\EstateBills\Residents;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
+use App\Estate;
 
 class GetAllBills extends Controller
 {
-	public function __invoke()
+    /**
+     * Gets authenticated user's data
+     *
+     * @return App\User
+     */
+    public function __construct()
+    {
+        $this->user = auth()->user();
+    }
+
+	/**
+	 * Gets all billable items for the user's estate
+	 * 
+     * @return \Illuminate\Http\Response
+	 */
+	public function __invoke(Estate $estate)
 	{
-		
+		// Get user's estate db resource identifier
+        $user_estate = $this->user->home->estate_id;
+
+        // Verify the existence of such an estate
+        $estate = $estate->find($user_estate);
+
+        // Check if such an estate exists
+        // You never can tell what may happen as bad users may spoof estate id
+        if(!$estate)
+        {
+            return response()->json([
+                'status'  => false,
+                'message' => 'Estate not found'
+            ], 404);
+        }
+
+        // Get all estate bills for the user's estate
+        $estate_bills = $estate->billableItems;
+
+        // Send response
+        return response()->json([
+        	'count'   => $estate_bills->count(),
+            'status'  => true,
+            'data'	  => $estate_bills
+        ], 200);
 	}
 }

--- a/routes/v1.php
+++ b/routes/v1.php
@@ -220,7 +220,7 @@ Route::group(['middleware' => ['jwt.verify']], function () {
 
         // for resident-user satisfied privileges
         Route::namespace('EstateBills\Residents')->group(function () {
-            Route::middleware(['estateAdmin'])->group(function(){
+            Route::middleware(['checkResident'])->group(function(){
                 Route::get('estate', GetAllBills::class);
             });
         });


### PR DESCRIPTION
## Summary
- **Add resident middleware to GET endpoint: /api/v1/bills/estate:** GET request made to the endpoint `/api/v1/bills/estate` must be made as a logged in resident user.
- Establish eloquent relationship between estate and estate bills models
- Add method for retrieving billable items for an estate
- **Rearrange response json data object:** The response sent had to be properly formatted for better understanding by the API consumers.

## Test
This pull request has been tested using Postman. When a **GET** request is sent to the endpoint `/api/v1/bills/estate` a response is gotten in the form of an array of billable items for the resident's estate.

Here is the success result in screenshot
![image](https://user-images.githubusercontent.com/54823365/69390099-6e353b00-0cce-11ea-9de6-8cbc3951da3c.png)

## Sample response
```json
{
    "count": 6,
    "status": true,
    "data": {
        "id": 3,
        "estate_name": "Peace Estate",
        "address": "Lekki",
        "city": "Lagos",
        "country": "Nigeria",
        "image": "noimage.jpg",
        "created_at": "2019-10-26 08:49:04",
        "updated_at": "2019-10-26 08:49:04",
        "billable_items": [
            {
                "estate_bills_id": 1,
                "item": "Electricity",
                "icon_link": "no-image.jpg",
                "base_amount": 1200
            },
            {
                "estate_bills_id": 2,
                "item": "Water",
                "icon_link": "no-image.jpg",
                "base_amount": 1200
            },
            {
                "estate_bills_id": 3,
                "item": "Internet",
                "icon_link": "no-image.jpg",
                "base_amount": 1200
            },
            {
                "estate_bills_id": 4,
                "item": "Waste",
                "icon_link": "no-image.jpg",
                "base_amount": 1200
            },
            {
                "estate_bills_id": 5,
                "item": "Security",
                "icon_link": "no-image.jpg",
                "base_amount": 1200
            },
            {
                "estate_bills_id": 6,
                "item": "Cable",
                "icon_link": "no-image.jpg",
                "base_amount": 1200
            }
        ]
    }
}
```

## Precaution taken over security concern
- [I ensured that the estate identifier retrieved is valid](https://github.com/hngi/Gateapp-api/commit/93803fb1d48732b797ea1c1a31b7645e7796269f#diff-79c31f00086ff1885289551481819a1eR35-R41)
- [I also ensured that the estate identifier could not be spoofed due to bad user's actions, by not relying on the user for the estate record identifier](https://github.com/hngi/Gateapp-api/commit/93803fb1d48732b797ea1c1a31b7645e7796269f#diff-79c31f00086ff1885289551481819a1eR28)
